### PR TITLE
Protect from concurrent calling of handlers

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -49,9 +49,9 @@ func ExitReload(prefix string, reload func(), breakdown func()) {
 	// Wait for exit signal
 	signal.Notify(sc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
 	<-done
-	isRunning = false
 	reloadingMutex.Lock()
 	defer reloadingMutex.Unlock()
+	isRunning = false
 	fmt.Println()
 
 	// Stop server

--- a/exit.go
+++ b/exit.go
@@ -22,8 +22,8 @@ func ExitReload(prefix string, reload func(), breakdown func()) {
 			case a := <-sc:
 				if a == syscall.SIGHUP {
 					go func() {
-						defer reloadingMutex.Unlock()
 						reloadingMutex.Lock()
+						defer reloadingMutex.Unlock()
 						if isRunning {
 							reload()
 						}


### PR DESCRIPTION
This patch protects from the following scenarios:

- One or more reloads happening at the same time.
- An exit and a reload happening at the same time.

This patch also add log messages for reload.